### PR TITLE
Implementing a struct for every N months

### DIFF
--- a/kronos/src/lib.rs
+++ b/kronos/src/lib.rs
@@ -6,7 +6,7 @@ pub use crate::types::{Grain, TimeSequence, Range, Season};
 mod utils;
 
 mod seq_named;
-pub use crate::seq_named::{Weekday, Month, Weekend, Year};
+pub use crate::seq_named::{Weekday, Month, NMonth, Weekend, Year};
 
 mod seq_grain;
 pub use crate::seq_grain::Grains;

--- a/kronos/src/seq_named.rs
+++ b/kronos/src/seq_named.rs
@@ -56,6 +56,33 @@ impl TimeSequence for Month {
     }
 }
 
+#[derive(Clone)]
+pub struct NMonth(pub u32, pub i32);
+
+impl NMonth {
+    fn _base(&self, t0: &DateTime, future: bool) -> Box<dyn Iterator<Item=Range>> {
+        let base = utils::truncate(*t0, Grain::Month).date();
+        let base = utils::find_month(base, self.0, future).and_hms(0, 0, 0);
+        let endshift = self.1;
+        let sign = if future { 1 } else { -1 };
+        Box::new((0..).map(move |x| Range{
+            start: utils::shift_datetime(base, Grain::Month, sign * endshift * x),
+            end: utils::shift_datetime(base, Grain::Month, sign * endshift * x + 1),
+            grain: Grain::Month
+        }))
+    }
+}
+
+impl TimeSequence for NMonth {
+    fn _future_raw(&self, t0: &DateTime) -> Box<dyn Iterator<Item=Range>> {
+        self._base(t0, true)
+    }
+
+    fn _past_raw(&self, t0: &DateTime) -> Box<dyn Iterator<Item=Range>> {
+        self._base(t0, false)
+    }
+}
+
 
 #[derive(Clone)]
 pub struct Weekend;

--- a/kronos/src/seq_named.rs
+++ b/kronos/src/seq_named.rs
@@ -214,6 +214,40 @@ mod test {
     }
 
     #[test]
+    fn nmonth() {
+        let t0_april = dt(2018, 4, 3);
+
+        // Standing on April, next third month after April is the same month
+        let it = NMonth(4, 3).future(&t0_april).next().unwrap();
+        assert_eq!(it, Range{
+            start: dt(2018, 4, 1), end: dt(2018, 5, 1), grain: Grain::Month});
+        
+        // Standing on April, next March is in the following year
+        let mut it = NMonth(3, 3).future(&t0_april);
+        assert_eq!(it.next().unwrap(), Range{
+            start: dt(2019, 3, 1), end: dt(2019, 4, 1), grain: Grain::Month});
+        // the next occurrence is June
+        assert_eq!(it.next().unwrap(), Range{
+            start: dt(2019, 6, 1), end: dt(2019, 7, 1), grain: Grain::Month});
+        
+        // Standing on April, next March is the month prior
+        let mut it = NMonth(3, 3).past(&t0_april);
+        assert_eq!(it.next().unwrap(), Range{
+            start: dt(2018, 3, 1), end: dt(2018, 4, 1), grain: Grain::Month});
+        // the next occurrence is December of the previous year
+        assert_eq!(it.next().unwrap(), Range{
+            start: dt(2017, 12, 1), end: dt(2018, 1, 1), grain: Grain::Month});
+        
+        // Standing on April, the next May is the next month
+        let mut it = NMonth(5, 7).future(&t0_april);
+        assert_eq!(it.next().unwrap(), Range{
+            start: dt(2018, 5, 1), end: dt(2018, 6, 1), grain: Grain::Month});
+        // the next seventh month is December
+        assert_eq!(it.next().unwrap(), Range{
+            start: dt(2018, 12, 1), end: dt(2019, 1, 1), grain: Grain::Month});
+    }
+
+    #[test]
     fn weekend() {
         // start from a Wednesday
         let mut weekend = Weekend.future(&dt(2016, 3, 23));


### PR DESCRIPTION
Hi @rodolf0,

I've recently started using Rust and wanted to work with some time sequences, and have found your kronos crate very useful.
For my use case, the only feature I found this crate was missing was something like a "every N months" `TimeSequence`.

I wanted to use the `MGrain` struct, but it uses a `Duration`, which is a fixed interval that only goes up to weeks.
Months, being flexible in the amount of time they contain, didn't fit that structure.

To do this, I made a new struct, `NMonth`, that is very similar to the `Month` struct, with a variable hop instead of the fixed 12 in the `Month`.
I know the feature somewhat overlaps the `Seasons` struct and `Quarter` and `Half` `Grain` variants a little bit, but it allows you to work with a number of months that doesn't evenly divide the year, like 5 months.

I'm not sure sure if you're taking PRs for this still, but I've seen some recent contributions in the commits, so hopefully you're still open to it.

I've tried to follow the style and structure of the library, but do let me know if there are implementation decisions, tests, or something else you'd like me to reconsider for this feature. Thanks.